### PR TITLE
Add LRU cache for router

### DIFF
--- a/apidaora/asgi/router.py
+++ b/apidaora/asgi/router.py
@@ -1,6 +1,7 @@
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import (
     Any,
     Callable,
@@ -106,6 +107,7 @@ def make_router(
 
         routes_tree_tmp[route.method.value] = route
 
+    @lru_cache(maxsize=1024 * 1024)
     def route_(path: str, method: str) -> ResolvedRoute:
         path_parts = split_path(path)
         path_args = {}

--- a/changelog.d/aeaa814.change
+++ b/changelog.d/aeaa814.change
@@ -1,0 +1,1 @@
+Add LRU cache for router to optimizing resolutions


### PR DESCRIPTION
Add LRU small cache to optimizing router resolutions, because some routes can be repetitive.